### PR TITLE
Add alternative table structure digest for late 10.11 versions

### DIFF
--- a/tccutil.py
+++ b/tccutil.py
@@ -112,7 +112,7 @@ def open_database():
       if not (
         accessTableDigest == "8e93d38f7c" #prior to El Capitan
         or
-        (osx_version >= version('10.11') and accessTableDigest=="9b2ea61b30")
+        (osx_version >= version('10.11') and accessTableDigest in ["9b2ea61b30", "1072dc0e4b"])
       ):
         print "TCC Database structure is unknown."
         sys.exit(1)


### PR DESCRIPTION
    * 9b2ea61b30 digest [early 10.11] is for:
    CREATE TABLE access ( service   TEXT  NOT NULL,   client    TEXT  NOT NULL,   client_type INTEGENOT NULL,   allowed   INTEGER NOT NULL,   prompt_count  INTEGER NOT NULL,   csreq   BLOB,   policy_id INTEGER,  PRIMARY KEY (service, client, client_type), FOREIGN KEY (policy_id) REFERENCES policies(id) ON DELETE CASCADE ON UPDATE CASCADE)

    * 1072dc0e4b digest [late 10.11, early 10.12] is for:
    CREATE TABLE "access" ( service   TEXT  NOT NULL,   client    TEXT  NOT NULL,   client_type INTEGENOT NULL,   allowed   INTEGER NOT NULL,   prompt_count  INTEGER NOT NULL,   csreq   BLOB,   policy_id INTEGER,  PRIMARY KEY (service, client, client_type), FOREIGN KEY (policy_id) REFERENCES policies(id) ON DELETE CASCADE ON UPDATE CASCADE)