### PR TITLE
Add insert support for Catalina

### DIFF
--- a/tccutil.py
+++ b/tccutil.py
@@ -11,7 +11,7 @@ from distutils.version import StrictVersion as version
 util_name = os.path.basename(sys.argv[0])
 
 # Utility Version
-util_version = '1.2.4'
+util_version = '1.2.5'
 
 # Current OS X version
 osx_version = version(mac_ver()[0])
@@ -104,8 +104,10 @@ def open_database():
             break
         # check if table in DB has expected structure:
         if not (accessTableDigest == "8e93d38f7c"  # prior to El Capitan
-                or (osx_version >= version('10.11') and accessTableDigest in
-                    ["9b2ea61b30", "1072dc0e4b", "80a4bb6912"])):
+                or (osx_version >= version('10.11')  # El Capitan through Mojave
+		    and accessTableDigest in ["9b2ea61b30", "1072dc0e4b", "80a4bb6912"])
+                or (osx_version >= version('10.15')  # Catalina and later
+		    and accessTableDigest == "ecc443615f")):
             print("TCC Database structure is unknown.")
             sys.exit(1)
 
@@ -192,7 +194,11 @@ def insert_client(client):
     # as the default value to enable it is different.
     cli_util_or_bundle_id(client)
     verbose_output("Inserting \"%s\" into Database..." % (client))
-    if osx_version >= version('10.11'):  # El Capitan or higher.
+    if osx_version >= version('10.15'):  # Catalina and later
+        c.execute("INSERT or REPLACE INTO \
+access VALUES('kTCCServiceAccessibility','%s',%s,1,1,NULL,NULL,NULL,'UNUSED',NULL,0,NULL)"
+                  % (client, client_type))
+    elif osx_version >= version('10.11'):  # El Capitan through Mojave
         c.execute("INSERT or REPLACE INTO \
 access VALUES('kTCCServiceAccessibility','%s',%s,1,1,NULL,NULL)"
                   % (client, client_type))


### PR DESCRIPTION
For anyone else with SIP disabled that's still happily using `tccutil` in spite of #18 — there was some brief mention of this previously (in comments on #28), but it looks like the schema fo the `access` table has changed in Catalina.

There seem to be only a few columns added (and all of them work fine with some default values)

```
indirect_object_identifier_type    INTEGER,
indirect_object_identifier         TEXT,
indirect_object_code_identity      BLOB,
flags                              INTEGER, 
last_modified                      INTEGER NOT NULL DEFAULT (CAST(strftime('%s','now') AS INTEGER)
```

Tested the change with macOS 10.15.1 and it works well — based on the comments in #28 (where the error message called out an addition of 5 unexpected columns, back in March) I'm optimistic this is generally applicable to 10.15.0 as well.

Brief summary of changes:

- Add a new case within `insert_client` for macOS 10.15+ that handles the above five columns
- Add a new `accessTableDigest` check specific to macOS 10.15+
- Bump util_version