### PR TITLE
Fix for Mojave/Catalina

### DIFF
--- a/tccutil.py
+++ b/tccutil.py
@@ -196,7 +196,7 @@ def insert_client(client):
     verbose_output("Inserting \"%s\" into Database..." % (client))
     if osx_version >= version('10.14'):  # Mojave and later
         c.execute("INSERT or REPLACE INTO \
-access VALUES('kTCCServiceAccessibility','%s',%s,1,1,NULL,NULL,NULL,'UNUSED',NULL,0,strftime('%s','now'))"
+access VALUES('kTCCServiceAccessibility','%s',%s,1,1,NULL,NULL,NULL,'UNUSED',NULL,0,0)"
                   % (client, client_type))
     elif osx_version >= version('10.11'):  # El Capitan through Mojave
         c.execute("INSERT or REPLACE INTO \

--- a/tccutil.py
+++ b/tccutil.py
@@ -11,7 +11,7 @@ from distutils.version import StrictVersion as version
 util_name = os.path.basename(sys.argv[0])
 
 # Utility Version
-util_version = '1.2.5'
+util_version = '1.2.6'
 
 # Current OS X version
 osx_version = version(mac_ver()[0])
@@ -104,10 +104,10 @@ def open_database():
             break
         # check if table in DB has expected structure:
         if not (accessTableDigest == "8e93d38f7c"  # prior to El Capitan
-                or (osx_version >= version('10.11')  # El Capitan through Mojave
-		    and accessTableDigest in ["9b2ea61b30", "1072dc0e4b", "80a4bb6912"])
-                or (osx_version >= version('10.15')  # Catalina and later
-		    and accessTableDigest == "ecc443615f")):
+                or (osx_version >= version('10.11')  # El Capitan , Sierra, High Sierra
+		    and accessTableDigest in ["9b2ea61b30", "1072dc0e4b"])
+                or (osx_version >= version('10.14')  # Mojave and later
+		    and accessTableDigest in ["ecc443615f", "80a4bb6912"])):
             print("TCC Database structure is unknown.")
             sys.exit(1)
 
@@ -194,9 +194,9 @@ def insert_client(client):
     # as the default value to enable it is different.
     cli_util_or_bundle_id(client)
     verbose_output("Inserting \"%s\" into Database..." % (client))
-    if osx_version >= version('10.15'):  # Catalina and later
+    if osx_version >= version('10.14'):  # Mojave and later
         c.execute("INSERT or REPLACE INTO \
-access VALUES('kTCCServiceAccessibility','%s',%s,1,1,NULL,NULL,NULL,'UNUSED',NULL,0,NULL)"
+access VALUES('kTCCServiceAccessibility','%s',%s,1,1,NULL,NULL,NULL,'UNUSED',NULL,0,strftime('%s','now'))"
                   % (client, client_type))
     elif osx_version >= version('10.11'):  # El Capitan through Mojave
         c.execute("INSERT or REPLACE INTO \


### PR DESCRIPTION
I checked a lot of macOS hosts (~850) and collected information about SQLite schema for TCC.db.
List of structures on different versions.
**macOS 10.10**
- 8e93d38f7c

**macOS 10.12**
- 1072dc0e4b
- 9b2ea61b30

**macOS 10.13**
- 1072dc0e4b
- 9b2ea61b30

**macOS 10.14**
- 80a4bb6912
- ecc443615f

**macOS 10.15**
- ecc443615f

**8e93d38f7c**
```sql
CREATE TABLE access (
  service TEXT NOT NULL,
  client TEXT NOT NULL,
  client_type INTEGER NOT NULL,
  allowed INTEGER NOT NULL,
  prompt_count INTEGER NOT NULL,
  csreq BLOB, CONSTRAINT key PRIMARY KEY (service, client, client_type));
```
**1072dc0e4b**
```sql
CREATE TABLE "access"(
  service	TEXT	NOT NULL,
  client	TEXT	NOT NULL,
  client_type	INTEGER	NOT NULL,
  allowed	INTEGER	NOT NULL,
  prompt_count	INTEGER	NOT NULL,
  csreq	BLOB,
  policy_id	INTEGER,
  PRIMARY KEY(service, client, client_type),
  FOREIGN KEY(policy_id) REFERENCES policies(id) ON DELETE CASCADE ON UPDATE CASCADE
);
```
**9b2ea61b30**
```sql
CREATE TABLE access(
  service	TEXT	NOT NULL,
  client	TEXT	NOT NULL,
  client_type	INTEGER	NOT NULL,
  allowed	INTEGER	NOT NULL,
  prompt_count	INTEGER	NOT NULL,
  csreq	BLOB,
  policy_id	INTEGER,
  PRIMARY KEY(service, client, client_type),
  FOREIGN KEY(policy_id) REFERENCES policies(id) ON DELETE CASCADE ON UPDATE CASCADE
);
```
**80a4bb6912**
```sql
CREATE TABLE IF NOT EXISTS "access"(
  service TEXT NOT NULL,
  client TEXT NOT NULL,
  client_type INTEGER NOT NULL,
  allowed INTEGER NOT NULL,
  prompt_count INTEGER NOT NULL,
  csreq BLOB,
  policy_id INTEGER,
  indirect_object_identifier_type INTEGER,
  indirect_object_identifier TEXT DEFAULT 'UNUSED',
  indirect_object_code_identity BLOB,
  flags INTEGER,
  last_modified INTEGER NOT NULL DEFAULT(CAST(strftime('%s','now') AS INTEGER)),
  PRIMARY KEY(service, client, client_type, indirect_object_identifier),
  FOREIGN KEY(policy_id) REFERENCES policies(id) ON DELETE CASCADE ON UPDATE CASCADE
);
```
**ecc443615f**
```sql
CREATE TABLE access(
  service TEXT NOT NULL,
  client TEXT NOT NULL,
  client_type INTEGER NOT NULL,
  allowed INTEGER NOT NULL,
  prompt_count INTEGER NOT NULL,
  csreq BLOB,
  policy_id INTEGER,
  indirect_object_identifier_type INTEGER,
  indirect_object_identifier TEXT,
  indirect_object_code_identity BLOB,
  flags INTEGER,
  last_modified INTEGER NOT NULL DEFAULT(CAST(strftime('%s','now') AS INTEGER)),
  PRIMARY KEY(service, client, client_type, indirect_object_identifier),
  FOREIGN KEY(policy_id) REFERENCES policies(id) ON DELETE CASCADE ON UPDATE CASCADE
);
```
Examples:
```bash
izmal:~ admin$ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.14.5
BuildVersion:	18F132
browser-ios03:~ admin$ sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db"
SQLite version 3.24.0 2018-06-04 14:10:15
Enter ".help" for usage hints.
sqlite> .dump
PRAGMA foreign_keys=OFF;
BEGIN TRANSACTION;
CREATE TABLE admin (key TEXT PRIMARY KEY NOT NULL, value INTEGER NOT NULL);
INSERT INTO admin VALUES('version',15);
CREATE TABLE policies (	id		INTEGER	NOT NULL PRIMARY KEY, 	bundle_id	TEXT	NOT NULL, 	uuid		TEXT	NOT NULL, 	display		TEXT	NOT NULL, 	UNIQUE (bundle_id, uuid));
CREATE TABLE active_policy (	client		TEXT	NOT NULL, 	client_type	INTEGER	NOT NULL, 	policy_id	INTEGER NOT NULL, 	PRIMARY KEY (client, client_type), 	FOREIGN KEY (policy_id) REFERENCES policies(id) ON DELETE CASCADE ON UPDATE CASCADE);
CREATE TABLE access_overrides (	service		TEXT	NOT NULL PRIMARY KEY);
CREATE TABLE IF NOT EXISTS "access" (    service        TEXT        NOT NULL,     client         TEXT        NOT NULL,     client_type    INTEGER     NOT NULL,     allowed        INTEGER     NOT NULL,     prompt_count   INTEGER     NOT NULL,     csreq          BLOB,     policy_id      INTEGER,     indirect_object_identifier_type    INTEGER,     indirect_object_identifier         TEXT DEFAULT 'UNUSED',     indirect_object_code_identity      BLOB,     flags          INTEGER,     last_modified  INTEGER     NOT NULL DEFAULT (CAST(strftime('%s','now') AS INTEGER)),     PRIMARY KEY (service, client, client_type, indirect_object_identifier),    FOREIGN KEY (policy_id) REFERENCES policies(id) ON DELETE CASCADE ON UPDATE CASCADE);
INSERT INTO access VALUES('kTCCServiceAccessibility','com.apple.Terminal',0,1,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1554474196);
INSERT INTO access VALUES('kTCCServicePostEvent','com.apple.screensharing.agent',0,1,1,NULL,NULL,NULL,'UNUSED',NULL,0,1554474196);
INSERT INTO access VALUES('kTCCServicePostEvent','com.apple.Terminal',0,1,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,NULL,'UNUSED',NULL,0,1554481027);
INSERT INTO access VALUES('kTCCServiceAccessibility','/usr/bin/ssh',1,1,1,NULL,NULL,NULL,'UNUSED',NULL,0,1579275979);
INSERT INTO access VALUES('kTCCServiceAccessibility','/usr/bin/touch',1,1,1,NULL,NULL,NULL,'UNUSED',NULL,0,1579276447);
CREATE TABLE expired (    service        TEXT        NOT NULL,     client         TEXT        NOT NULL,     client_type    INTEGER     NOT NULL,     csreq          BLOB,     last_modified  INTEGER     NOT NULL ,     expired_at     INTEGER     NOT NULL DEFAULT (CAST(strftime('%s','now') AS INTEGER)),     PRIMARY KEY (service, client, client_type));
CREATE INDEX active_policy_id ON active_policy(policy_id);
COMMIT;
sqlite>
sqlite> .schema --indent
CREATE TABLE admin(key TEXT PRIMARY KEY NOT NULL, value INTEGER NOT NULL);
CREATE TABLE policies(
  id	INTEGER	NOT NULL PRIMARY KEY,
  bundle_id	TEXT	NOT NULL,
  uuid	TEXT	NOT NULL,
  display	TEXT	NOT NULL,
  UNIQUE(bundle_id, uuid)
);
CREATE TABLE active_policy(
  client	TEXT	NOT NULL,
  client_type	INTEGER	NOT NULL,
  policy_id	INTEGER NOT NULL,
  PRIMARY KEY(client, client_type),
  FOREIGN KEY(policy_id) REFERENCES policies(id) ON DELETE CASCADE ON UPDATE CASCADE
);
CREATE INDEX active_policy_id ON active_policy(policy_id);
CREATE TABLE access_overrides(service	TEXT	NOT NULL PRIMARY KEY);
CREATE TABLE IF NOT EXISTS "access"(
  service TEXT NOT NULL,
  client TEXT NOT NULL,
  client_type INTEGER NOT NULL,
  allowed INTEGER NOT NULL,
  prompt_count INTEGER NOT NULL,
  csreq BLOB,
  policy_id INTEGER,
  indirect_object_identifier_type INTEGER,
  indirect_object_identifier TEXT DEFAULT 'UNUSED',
  indirect_object_code_identity BLOB,
  flags INTEGER,
  last_modified INTEGER NOT NULL DEFAULT(CAST(strftime('%s','now') AS INTEGER)),
  PRIMARY KEY(service, client, client_type, indirect_object_identifier),
  FOREIGN KEY(policy_id) REFERENCES policies(id) ON DELETE CASCADE ON UPDATE CASCADE
);
CREATE TABLE expired(
  service TEXT NOT NULL,
  client TEXT NOT NULL,
  client_type INTEGER NOT NULL,
  csreq BLOB,
  last_modified INTEGER NOT NULL ,
  expired_at INTEGER NOT NULL DEFAULT(CAST(strftime('%s','now') AS INTEGER)),
  PRIMARY KEY(service, client, client_type)
);
sqlite>
```