### PR TITLE
Fix deprecation of distutils Version classes

### DIFF
--- a/tccutil.py
+++ b/tccutil.py
@@ -23,7 +23,7 @@ from packaging.version import Version as version
 util_name = os.path.basename(sys.argv[0])
 
 # Utility Version
-util_version = '1.2.11'
+util_version = '1.2.12'
 
 # Current OS X version
 osx_version = version(mac_ver()[0])  # mac_ver() returns 10.16 for Big Sur instead 11.+

--- a/tccutil.py
+++ b/tccutil.py
@@ -17,7 +17,7 @@ import sys
 import os
 import hashlib
 from platform import mac_ver
-from distutils.version import StrictVersion as version
+from packaging.version import Version as version
 
 # Utility Name
 util_name = os.path.basename(sys.argv[0])


### PR DESCRIPTION
Fix the following warning:

DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.

Issue: #57