### PR TITLE
Sonoma fixes

### DIFF
--- a/tccutil.py
+++ b/tccutil.py
@@ -160,7 +160,7 @@ def open_database(digest=False):
                    accessTableDigest in ["3d1c2a0e97", "cef70648de"]) or
                 # Sonoma
                 (osx_version >= version('14.0') and
-                   accessTableDigest in ["34abf99d20"])
+                   accessTableDigest in ["34abf99d20", "e3a2181c14"])
                 ):
             print(f"TCC Database structure is unknown ({accessTableDigest})", file=sys.stderr)
             sys.exit(1)

--- a/tccutil.py
+++ b/tccutil.py
@@ -249,7 +249,7 @@ def insert_client(client):
     client_type = cli_util_or_bundle_id(client)
     verbose_output(f'Inserting "{client}" into Database...')
     # Sonoma
-    if osx_version >= version('10.16'):
+    if osx_version >= version('14.0'):
         try:
           c.execute(f"INSERT or REPLACE INTO access VALUES('{service}','{client}',{client_type},2,4,1,NULL,NULL,0,'UNUSED',NULL,0, NULL, NULL, NULL,'UNUSED', NULL)")
         except sqlite3.OperationalError:


### PR DESCRIPTION
This fixes a broken version check that was added in the last commit, and adds another digest for the sonoma access table. Here's my access table:

```
CREATE TABLE access (    service        TEXT        NOT NULL,     client         TEXT        NOT NULL,     client_type    INTEGER     NOT NULL,     auth_value     INTEGER     NOT NULL,     auth_reason    INTEGER     NOT NULL,     auth_version   INTEGER     NOT NULL,     csreq          BLOB,     policy_id      INTEGER,     indirect_object_identifier_type    INTEGER,     indirect_object_identifier         TEXT NOT NULL DEFAULT 'UNUSED',     indirect_object_code_identity      BLOB,     flags          INTEGER,     last_modified  INTEGER     NOT NULL DEFAULT (CAST(strftime('%s','now') AS INTEGER)), pid INTEGER, pid_version INTEGER, boot_uuid TEXT NOT NULL DEFAULT 'UNUSED', last_reminded INTEGER NOT NULL DEFAULT 0,     PRIMARY KEY (service, client, client_type, indirect_object_identifier),    FOREIGN KEY (policy_id) REFERENCES policies(id) ON DELETE CASCADE ON UPDATE CASCADE)
```