### PR TITLE
macOS 12+ uses `auth_value=2` to enable an application

### DIFF
--- a/tccutil.py
+++ b/tccutil.py
@@ -291,8 +291,9 @@ def enable(client):
     # right away (without closing the window).
     # Set to 1 to enable the client.
     enable_mode_name = 'auth_value' if osx_version >= version('10.16') else 'allowed'
+    enable_value = '2' if osx_version >= version('12.0') else '1'
     try:
-      c.execute(f"UPDATE access SET {enable_mode_name}='1' WHERE client='{client}' AND service IS '{service}'")
+      c.execute(f"UPDATE access SET {enable_mode_name}='{enable_value}' WHERE client='{client}' AND service IS '{service}'")
     except sqlite3.OperationalError:
       print("Attempting to write a readonly database.  You probably need to disable SIP.", file=sys.stderr)
     commit_changes()


### PR DESCRIPTION
This PR aims to fix #61 by changing the value the scripts sets the `auth_value` field to on macOS 12+.

Lacking more information/data I don't know if I rather use 12.4 (from the #61's OP) as a "pivot" version instead of 12.0 as I did.

Feel free to comment with more information.