### PR TITLE
f773496775 access table structure's digest should be trusted

### DIFF
--- a/tccutil.py
+++ b/tccutil.py
@@ -160,7 +160,7 @@ def open_database(digest=False):
                    accessTableDigest in ["3d1c2a0e97", "cef70648de"]) or
                 # Sonoma
                 (osx_version >= version('14.0') and
-                   accessTableDigest in ["34abf99d20", "e3a2181c14"])
+                   accessTableDigest in ["34abf99d20", "e3a2181c14", "f773496775"])
                 ):
             print(f"TCC Database structure is unknown ({accessTableDigest})", file=sys.stderr)
             sys.exit(1)


### PR DESCRIPTION
This PR aims to fix #70 by adding `f773496775` to the list of macOS 14 trusted access table structure's digests because it's a simple variation of an already trusted one.

The `SELECT sql FROM sqlite_master WHERE name='access' and type='table'` was producing the almost-same SQL:

* Non working (unknown): CREATE TABLE access (…
* Working (trusted): CREATE TABLE "access" (…

Note: This is a "simple" fix. A better one would be to lint obtained SQL in a common format.

Feel free to comment with more information.