### PR TITLE
fix --remove feature by passing service id to delete_client

### DIFF
--- a/tccutil.py
+++ b/tccutil.py
@@ -364,7 +364,7 @@ def main():
         return
 
     for item_to_remove in args.remove:
-        delete_client(item_to_remove)
+        delete_client(item_to_remove, service)
 
     for item in args.insert:
         insert_client(item)


### PR DESCRIPTION
resolves issue #75.

commit 20c8a11 added a parameter `service` to the `delete_client` function, but neglected to pass that argument when calling `delete_client` to remove an item from the service database. this broke the `--remove` feature.

this pull request just adds the missing argument.